### PR TITLE
Prevent crashing due to invalid range

### DIFF
--- a/Pod/Classes/GridCollectionViewLayout.swift
+++ b/Pod/Classes/GridCollectionViewLayout.swift
@@ -152,6 +152,7 @@ extension GridCollectionViewLayout {
         let startIndex = GridCollectionViewLayout.firstIndexInRow(startRow, withItemsPerRow: itemsPerRow)
         let endIndex = GridCollectionViewLayout.lastIndexInRow(endRow, withItemsPerRow: itemsPerRow, numberOfItems: items)
         
+        guard startIndex <= endIndex else { return [] }
         let indexPaths = (startIndex...endIndex).map { indexPathFromFlatIndex($0) }
 
         return indexPaths


### PR DESCRIPTION
- Guard against endIndex < startIndex when generating a range of indexPaths in `indexPathsInRect`
